### PR TITLE
civetweb: extend API to allow enforced connection close.

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -552,6 +552,9 @@ CIVETWEB_API char *mg_md5(char buf[33], ...);
 CIVETWEB_API void mg_cry(struct mg_connection *conn,
                          PRINTF_FORMAT_STRING(const char *fmt), ...) PRINTF_ARGS(2, 3);
 
+/* set connection's http status */
+CIVETWEB_API void mg_set_http_status(struct mg_connection *conn, int status);
+
 
 /* utility method to compare two buffers, case incensitive. */
 CIVETWEB_API int mg_strncasecmp(const char *s1, const char *s2, size_t len);

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -395,6 +395,11 @@ CIVETWEB_API void mg_send_file(struct mg_connection *conn, const char *path);
      > 0   number of bytes read into the buffer. */
 CIVETWEB_API int mg_read(struct mg_connection *, void *buf, size_t len);
 
+/* Enforce closing socket after serving current request even if connection
+ * is in keep-alive mode.
+ * Useful when serving content without specified length while keep-alive mode
+ * should be generally preserved. */
+CIVETWEB_API void mg_enforce_close(struct mg_connection *conn);
 
 /* Get the value of particular HTTP header.
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1145,6 +1145,11 @@ void mg_cry(struct mg_connection *conn, const char *fmt, ...)
     }
 }
 
+void mg_set_http_status(struct mg_connection *conn, int status)
+{
+    conn->status_code = status;
+}
+
 /* Return fake connection structure. Used for logging, if connection
    is not applicable at the moment of logging. */
 static struct mg_connection *fc(struct mg_context *ctx)

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2472,6 +2472,11 @@ int mg_vprintf(struct mg_connection *conn, const char *fmt, va_list ap)
     return len;
 }
 
+void mg_enforce_close(struct mg_connection *conn)
+{
+    conn->must_close = 1;
+}
+
 int mg_printf(struct mg_connection *conn, const char *fmt, ...)
 {
     va_list ap;


### PR DESCRIPTION
This feature would allow sending responses without specified content length while generally preserving ability to handle keep-alive connections.

Attaching commit 8d271315a541218caada366f84a2690fdbd474a2 as part of this PR because it is checkouted (and used) in current master branch of ceph.