### PR TITLE
civetweb: the "num_bytes_sent" in struct "mg_connection" is always 0 …

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2389,6 +2389,7 @@ int mg_write(struct mg_connection *conn, const void *buf, size_t len)
         total = push(NULL, conn->client.sock, conn->ssl, (const char *) buf,
                      (int64_t) len);
     }
+    conn->num_bytes_sent += total;
     return (int) total;
 }
 


### PR DESCRIPTION
…when download a file

When start radosgw with civetweb and then download a file,  the "num_bytes_sent" is always 0 in the access log.
