### PR TITLE
fix "defined but not used" warning

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3994,6 +3994,7 @@ static void parse_http_headers(char **buf, struct mg_request_info *ri)
     }
 }
 
+#ifndef RGW
 static int is_valid_http_method(const char *method)
 {
     return !strcmp(method, "GET") || !strcmp(method, "POST") ||
@@ -4003,6 +4004,7 @@ static int is_valid_http_method(const char *method)
            || !strcmp(method, "MKCOL")
            ;
 }
+#endif
 
 /* Parse HTTP request, fill in mg_request_info structure.
    This function modifies the buffer by NUL-terminating


### PR DESCRIPTION
```
[ 85%] Building C object src/CMakeFiles/radosgw.dir/civetweb/src/civetweb.c.o
Scanning dependencies of target test_rados_open_pools_parallel
[ 85%] Building CXX object src/test/CMakeFiles/test_rados_open_pools_parallel.dir/system/rados_open_pools_parallel.cc.o
warning: /srv/autobuild-ceph/gitbuilder.git/build/src/civetweb/src/civetweb.c:3997:12: ‘is_valid_http_method’ defined but not used [-Wunused-function]
static int is_valid_http_method(const char *method)
^
```

so "is_valid_http_method" is defined but not used if "RGW" is defined,
and we can disable it in that case.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>