### PR TITLE
Add "mg_get_local_addr".  Return the local listening address used.

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -304,6 +304,8 @@ CIVETWEB_API int mg_modify_passwords_file(const char *passwords_file_name,
 /* Return information associated with the request. */
 CIVETWEB_API struct mg_request_info *mg_get_request_info(struct mg_connection *);
 
+CIVETWEB_API struct sockaddr *mg_get_local_addr(struct mg_connection *);
+
 
 /* Send data to the client.
    Return:

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1169,6 +1169,11 @@ struct mg_request_info *mg_get_request_info(struct mg_connection *conn)
     return &conn->request_info;
 }
 
+struct sockaddr *mg_get_local_addr(struct mg_connection *conn)
+{
+    return &conn->client.lsa.sa;
+}
+
 /* Skip the characters until one of the delimiters characters found.
    0-terminate resulting word. Skip the delimiter and following whitespaces.
    Advance pointer to buffer to the next word. Return found 0-terminated word.


### PR DESCRIPTION
civetweb can listen to multiple addresses.  Some of these can have
ssl enabled, and some not.  The "using_ssl" flag is
already returned to the client, but the local address (lsa) is not,
This allows a calling application to determine on which local
address/portno a connection was accepted.

Signed-off-by: Marcus Watts <mwatts@redhat.com>