### PR TITLE
Allow using sub-domains in absolute URIs

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1070,6 +1070,7 @@ enum {
 	CGI_INTERPRETER,
 	PROTECT_URI,
 	AUTHENTICATION_DOMAIN,
+	ENABLE_AUTH_DOMAIN_CHECK,
 	SSI_EXTENSIONS,
 	THROTTLE,
 	ACCESS_LOG_FILE,
@@ -1138,6 +1139,7 @@ static struct mg_option config_options[] = {
     {"cgi_interpreter", CONFIG_TYPE_FILE, NULL},
     {"protect_uri", CONFIG_TYPE_STRING, NULL},
     {"authentication_domain", CONFIG_TYPE_STRING, "mydomain.com"},
+    {"enable_auth_domain_check", CONFIG_TYPE_BOOLEAN, "yes"},
     {"ssi_pattern", CONFIG_TYPE_EXT_PATTERN, "**.shtml$|**.shtm$"},
     {"throttle", CONFIG_TYPE_STRING, NULL},
     {"access_log_file", CONFIG_TYPE_FILE, NULL},
@@ -11763,16 +11765,18 @@ get_rel_url_at_current_server(const char *uri, const struct mg_connection *conn)
 	size_t server_domain_len;
 	size_t request_domain_len = 0;
 	unsigned long port = 0;
-	int i;
+	int i, auth_domain_check_enabled;
 	const char *hostbegin = NULL;
 	const char *hostend = NULL;
 	const char *portbegin;
 	char *portend;
 
+	auth_domain_check_enabled =
+		!strcmp(conn->ctx->config[ENABLE_AUTH_DOMAIN_CHECK],"yes");
 	/* DNS is case insensitive, so use case insensitive string compare here
 	 */
 	server_domain = conn->ctx->config[AUTHENTICATION_DOMAIN];
-	if (!server_domain) {
+	if (!server_domain && auth_domain_check_enabled) {
 		return 0;
 	}
 	server_domain_len = strlen(server_domain);
@@ -11835,28 +11839,30 @@ get_rel_url_at_current_server(const char *uri, const struct mg_connection *conn)
 	 * but do not allow substrings (like http://notmydomain.com/path/file.ext
 	 * or http://mydomain.com.fake/path/file.ext).
 	 */
-	if ((request_domain_len == server_domain_len)
-	    && (!memcmp(server_domain, hostbegin, server_domain_len))) {
-		/* Request is directed to this server - full name match. */
-	} else {
-		if (request_domain_len < (server_domain_len + 2)) {
-			/* Request is directed to another server: The server name is longer
-			 * than
-			 * the request name. Drop this case here to avoid overflows in the
-			 * following checks. */
-			return 0;
-		}
-		if (hostbegin[request_domain_len - server_domain_len - 1] != '.') {
-			/* Request is directed to another server: It could be a substring
-			 * like notmyserver.com */
-			return 0;
-		}
-		if (0 != memcmp(server_domain,
-		                hostbegin + request_domain_len - server_domain_len,
-		                server_domain_len)) {
-			/* Request is directed to another server:
-			 * The server name is different. */
-			return 0;
+	if (auth_domain_check_enabled) {
+		if ((request_domain_len == server_domain_len)
+				&& (!memcmp(server_domain, hostbegin, server_domain_len))) {
+			/* Request is directed to this server - full name match. */
+		} else {
+			if (request_domain_len < (server_domain_len + 2)) {
+				/* Request is directed to another server: The server name is longer
+				 * than
+				 * the request name. Drop this case here to avoid overflows in the
+				 * following checks. */
+				return 0;
+			}
+			if (hostbegin[request_domain_len - server_domain_len - 1] != '.') {
+				/* Request is directed to another server: It could be a substring
+				 * like notmyserver.com */
+				return 0;
+			}
+			if (0 != memcmp(server_domain,
+											hostbegin + request_domain_len - server_domain_len,
+											server_domain_len)) {
+				/* Request is directed to another server:
+				 * The server name is different. */
+				return 0;
+			}
 		}
 	}
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -11811,6 +11811,8 @@ get_rel_url_at_current_server(const char *uri, const struct mg_connection *conn)
 		return 0;
 	}
 
+/* Check if the request is directed to a different server. */
+/* First check if the port is the same (IPv4 and IPv6). */
 #if defined(USE_IPV6)
 	if (conn->client.lsa.sa.sa_family == AF_INET6) {
 		if (ntohs(conn->client.lsa.sin6.sin6_port) != port) {
@@ -11826,10 +11828,36 @@ get_rel_url_at_current_server(const char *uri, const struct mg_connection *conn)
 		}
 	}
 
-	if ((request_domain_len != server_domain_len)
-	    || (0 != memcmp(server_domain, hostbegin, server_domain_len))) {
-		/* Request is directed to another server */
-		return 0;
+	/* Finally check if the server corresponds to the authentication
+	 * domain of the server (the server domain).
+	 * Allow full matches (like http://mydomain.com/path/file.ext), and
+	 * allow subdomain matches (like http://www.mydomain.com/path/file.ext),
+	 * but do not allow substrings (like http://notmydomain.com/path/file.ext
+	 * or http://mydomain.com.fake/path/file.ext).
+	 */
+	if ((request_domain_len == server_domain_len)
+	    && (!memcmp(server_domain, hostbegin, server_domain_len))) {
+		/* Request is directed to this server - full name match. */
+	} else {
+		if (request_domain_len < (server_domain_len + 2)) {
+			/* Request is directed to another server: The server name is longer
+			 * than
+			 * the request name. Drop this case here to avoid overflows in the
+			 * following checks. */
+			return 0;
+		}
+		if (hostbegin[request_domain_len - server_domain_len - 1] != '.') {
+			/* Request is directed to another server: It could be a substring
+			 * like notmyserver.com */
+			return 0;
+		}
+		if (0 != memcmp(server_domain,
+		                hostbegin + request_domain_len - server_domain_len,
+		                server_domain_len)) {
+			/* Request is directed to another server:
+			 * The server name is different. */
+			return 0;
+		}
 	}
 
 	return hostend;

--- a/test/public_server.c
+++ b/test/public_server.c
@@ -1429,6 +1429,32 @@ START_TEST(test_request_handlers)
 	ck_assert_str_eq(buf, expected);
 	mg_close_connection(client_conn);
 
+	/* Get data from callback using mg_connect_client and absolute URI with a
+	 * sub-domain */
+	memset(ebuf, 0, sizeof(ebuf));
+	client_conn =
+	    mg_connect_client("localhost", ipv4_port, 0, ebuf, sizeof(ebuf));
+	ck_assert(client_conn != NULL);
+	ck_assert_str_eq(ebuf, "");
+
+	mg_printf(client_conn,
+	          "GET http://subdomain.test.domain:%d/U7 HTTP/1.0\r\n\r\n",
+	          ipv4_port);
+
+	i = mg_get_response(client_conn, ebuf, sizeof(ebuf), 10000);
+	ck_assert_int_ge(i, 0);
+	ck_assert_str_eq(ebuf, "");
+
+	ri = mg_get_request_info(client_conn);
+
+	ck_assert(ri != NULL);
+	ck_assert_str_eq(ri->uri, "200");
+	i = mg_read(client_conn, buf, sizeof(buf));
+	ck_assert_int_eq(i, (int)strlen(expected));
+	buf[i] = 0;
+	ck_assert_str_eq(buf, expected);
+	mg_close_connection(client_conn);
+
 
 /* Websocket test */
 #ifdef USE_WEBSOCKET
@@ -2824,13 +2850,12 @@ MAIN_PUBLIC_SERVER(void)
 	    test_threading(0);
 	    */
 	test_mg_start_stop_http_server(0);
-	/*
-	test_mg_start_stop_https_server(0);
+  // test_mg_start_stop_https_server(0);
 	test_request_handlers(0);
-	test_mg_server_and_client_tls(0);
-	test_handle_form(0);
-	test_http_auth(0);
-*/
+	// test_mg_server_and_client_tls(0);
+	// test_handle_form(0);
+	// test_http_auth(0);
+	test_keep_alive(0);
 
 	printf("\nok: %i\nfailed: %i\n\n", chk_ok, chk_failed);
 }


### PR DESCRIPTION
This allows to match bucketA.s3.example.com and bucketB.s3.example.com if the authentication domain is set to s3.example.com
See comment https://github.com/civetweb/civetweb/issues/197#issuecomment-255186417

(cherry picked from commit 3b4792d691028647eb65d9f248102205e4e961ed)

Conflicts:
  test/public_server.c
trivial merge conflict