### PR TITLE
mimic: Wait for ready socket using poll instead of select

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -5607,33 +5607,17 @@ push_inner(struct mg_context *ctx,
 			 * maybe an average disk seek time. */
 			mg_sleep(ms_wait > 10 ? 10 : ms_wait);
 		} else {
-			/* For sockets, wait for the socket using select */
-			fd_set wfds;
-			struct timeval tv;
-			int sret;
+			/* For sockets, wait for the socket using poll */
+			struct pollfd pfd[1];
+			int pollres;
 
-#if defined(__GNUC__) || defined(__MINGW32__)
-/* GCC seems to have a flaw with it's own socket macros:
- * http://www.linuxquestions.org/questions/programming-9/impossible-to-use-gcc-with-wconversion-and-standard-socket-macros-841935/
- */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#endif
-
-			FD_ZERO(&wfds);
-			FD_SET(sock, &wfds);
-			tv.tv_sec = (time_t)(ms_wait / 1000);
-			tv.tv_usec = (long)((ms_wait % 1000) * 1000);
-
-			sret = select((int)sock + 1, NULL, &wfds, NULL, &tv);
-
-#if defined(__GNUC__) || defined(__MINGW32__)
-#pragma GCC diagnostic pop
-#endif
-
-			if (sret > 0) {
-				/* We got ready to write. Don't check the timeout
-				 * but directly go back to write again. */
+			pfd[0].fd = sock;
+			pfd[0].events = POLLOUT;
+			pollres = mg_poll(pfd, 1, (int)(ms_wait), &(ctx->stop_flag));
+			if (ctx->stop_flag) {
+				return -2;
+			}
+			if (pollres > 0) {
 				continue;
 			}
 		}


### PR DESCRIPTION
(cherry picked from commit 19b55bf26b1f1b796c4a83a176a246ca4656a705)

Backport of the poll changes to mimic