### PR TITLE
Fix file descriptor leak.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16252,6 +16252,9 @@ worker_thread_run(struct worker_thread_args *thread_args)
 					conn->request_info.client_cert = 0;
 				}
 			}
+			else {
+				close_connection(conn);
+			}
 #endif
 		} else {
 			/* process HTTP connection */


### PR DESCRIPTION
If the openssl initial negotiation fails, then the rest of
what sslize does doesn't happen.  One of the last things
sslize does is to close the socket at the end of the session.
That needs to happen even if there's no session.

Signed-off-by: Marcus Watts <mwatts@redhat.com>