### PR TITLE
Wip chunkfix

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -1007,6 +1007,9 @@ mg_download(const char *host,
 /* Close the connection opened by mg_download(). */
 CIVETWEB_API void mg_close_connection(struct mg_connection *conn);
 
+CIVETWEB_API void mg_set_must_close(struct mg_connection *conn, int f);
+
+
 
 #if defined(MG_LEGACY_INTERFACE)
 /* File upload functionality. Each uploaded file gets saved into a temporary

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -15384,6 +15384,12 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 
 	/* Message is a valid request */
 	if ((cl = get_header(conn->request_info.http_headers,
+	                            conn->request_info.num_headers,
+	                            "Transfer-Encoding")) != NULL
+	           && !mg_strcasecmp(cl, "chunked")) {
+		conn->is_chunked = 1;
+		conn->content_len = -1; /* unknown content length */
+	} else if ((cl = get_header(conn->request_info.http_headers,
 	                     conn->request_info.num_headers,
 	                     "Content-Length")) != NULL) {
 		/* Request/response has content length set */
@@ -15401,12 +15407,6 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 		}
 		/* Publish the content length back to the request info. */
 		conn->request_info.content_length = conn->content_len;
-	} else if ((cl = get_header(conn->request_info.http_headers,
-	                            conn->request_info.num_headers,
-	                            "Transfer-Encoding")) != NULL
-	           && !mg_strcasecmp(cl, "chunked")) {
-		conn->is_chunked = 1;
-		conn->content_len = -1; /* unknown content length */
 	} else if (get_http_method_info(conn->request_info.request_method)
 	               ->request_has_body) {
 		/* POST or PUT request without content length set */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -14868,6 +14868,12 @@ mg_close_connection(struct mg_connection *conn)
 #endif /* defined(USE_WEBSOCKET) */
 }
 
+void
+mg_set_must_close(struct mg_connection *conn, int f)
+{
+	conn->must_close = f;
+}
+
 
 /* Only for memory statistics */
 static struct mg_context common_client_context;


### PR DESCRIPTION
3 fixes here.

1 content-length vs. transfer-encoding: chunked; according to rfc 2616,
transfer-encoding chunked should supersede content-length.  Later rfcs require this be treated as an error - sadly experience has shown s3 clients lag in this respect.

2. boto2 fixes.  Older versions of ceph (up to mid-luminous) worked with boto2; but the newer civetweb adopted in msater then backported to luminous is pickier and hates boto2.  Even though boto2 appears to be abandonware it still seems like a good idea (to me) to fix this.

3. mg_set_must_close,   Gives ceph/rgw a way to say this connection is hosed, do not attempt to read another request out of it.

These are all issues from,
https://tracker.ceph.com/issues/45789